### PR TITLE
Allow for entire template to be lazily loaded

### DIFF
--- a/flasgger/__init__.py
+++ b/flasgger/__init__.py
@@ -6,6 +6,6 @@ __email__ = 'rochacbruno@gmail.com'
 
 from jsonschema import ValidationError  # noqa
 from .base import Swagger, Flasgger, NO_SANITIZER, BR_SANITIZER, MK_SANITIZER, LazyJSONEncoder  # noqa
-from .utils import swag_from, validate, apispec_to_template, LazyString  # noqa
+from .utils import swag_from, validate, apispec_to_template, LazyString, LazyDict  # noqa
 from .marshmallow_apispec import APISpec, SwaggerView, Schema, fields  # noqa
 from .constants import OPTIONAL_FIELDS  # noqa


### PR DESCRIPTION
Previously only strings within a template could be lazily loaded. For frameworks like Eve, it would be useful to be able to generate the entire template at runtime, since routes are determined at runtime