### PR TITLE
Fix compatibility with Flask GraphQL

### DIFF
--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -80,7 +80,8 @@ def get_specs(rules, ignore_verbs, optional_fields, sanitizer, doc_dir=None):
             elif getattr(endpoint, 'methods', None) is not None:
                 if verb in endpoint.methods:
                     verb = verb.lower()
-                    methods[verb] = getattr(endpoint.view_class, verb)
+                    if hasattr(endpoint.view_class, verb):
+                        methods[verb] = getattr(endpoint.view_class, verb)
             else:
                 methods[verb.lower()] = endpoint
 


### PR DESCRIPTION
I started using Flask GraphQL (https://github.com/graphql-python/flask-graphql) and adding the `/graphlql` route as specified on their documentation triggered an undefined error:

```
File "/home/fauzruk/Dev/jaunefab/venv/lib/python3.7/site-packages/flasgger/utils.py", line 83, in get_specs
    methods[verb] = getattr(endpoint.view_class, verb)
AttributeError: type object 'GraphQLView' has no attribute 'delete'
```

This fix simply ignore the verb if the class does not have the method specified.