### PR TITLE
component section details not display issue fix(#318)

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -328,6 +328,11 @@ class Swagger(object):
             data["securityDefinitions"] = self.config.get(
                 'securityDefinitions'
             )
+        # enable 'components' when openapi_version is 3.*.*
+        if openapi_version and openapi_version.split('.')[0] == '3' and self.config.get("components"):
+            data["components"] = self.config.get(
+                'components'
+            )
         # set defaults from template
         if self.template is not None:
             data.update(self.template)


### PR DESCRIPTION
I got this issue when adding authentication from `swagger 2.0` to `OpenApi 3.0.2`. Earlier I had below settings in my `swagger_config` `dict`.

```python
swagger_config = {
    "headers": [],
    "specs": [
        {
            "endpoint": "swagger",
            "route": "/characteristics/swagger.json",
            "rule_filter": lambda rule: True,  # all in
            "model_filter": lambda tag: True,  # all in
        }
    ],
    "title": "Product Characteristics APIs",
    "version": '',
    "termsOfService": "",
    "static_url_path": "/characteristics/static",
    "swagger_ui": True,
    "specs_route": "/characteristics/swagger/",
    "description": "",
    "securityDefinitions": {
        "oAuthSample": {
            "type": "oauth2",
            "flow": "application",
            "tokenUrl": "https://api.pgsmartshopassistant.com/o/token/",
        }
    }
}
```

It's worked fine. When I move into` OpenApi 3.0.2` they changed `securityDefinitions` to `securitySchemes` under `components` with some other new naming conventions. So I changed it accordingly with `openapi` to `3.0.2`.

```python
swagger_config = {
    "openapi": "3.0.2",
    "components": {
        "securitySchemes": {
            "oAuthSample": {
                "type": "oauth2",
                "flows": {
                    "clientCredentials": {
                        "tokenUrl": "https://api.pgsmartshopassistant.com/o/token/",
                    }
                }
            }
        },
        "schemas": {
            "Product Characteristics": {
                "type": "object",
                "properties": {
                    "ean": {
                        "type": "string"
                    },
                    "i_q_name": {
                        "type": "string"
                    },
                    "id": {
                        "type": "integer"
                    },
                    "max": {
                        "type": "integer"
                    },
                    "min": {
                        "type": "integer"
                    },
                    "pack_size": {
                        "type": "integer"
                    },
                    "typical_use": {
                        "type": "number",
                        "format": "float"
                    },
                    "unit_count": {
                        "type": "integer"
                    },
                }
            }
        }
    },
    "specs": [
        {
            "endpoint": "swagger",
            "route": "/characteristics/swagger.json",
            "rule_filter": lambda rule: True,  # all in
            "model_filter": lambda tag: True,  # all in
        }
    ],
    "title": "Product Characteristics API",
    "version": '',
    "termsOfService": "",
    "static_url_path": "/characteristics/static",
    "swagger_ui": True,
    "specs_route": "/characteristics/swagger/",
    "description": "",
}
```

So this is not work with current version of `flasgger`. This [component](https://swagger.io/docs/specification/components/) is a new keyword from `OpenApi 3`. This is what documentation mention about it,

> components serve as a container for various reusable definitions – schemas (data models), parameters, responses, examples, and others. The definitions in components have no direct effect on the API unless you explicitly reference them from somewhere outside the components. That is, components are not parameters and responses that apply to all operations; they are just pieces of information to be referenced elsewhere. Under components, the definitions are grouped by type – schemas, parameters and so on. The following example lists the available subsections. All subsections are optional.

```python
components:
  # Reusable schemas (data models)
  schemas:
    ...
  # Reusable path, query, header and cookie parameters
  parameters:
    ...
  # Security scheme definitions (see Authentication)
  securitySchemes:
    ...
  # Reusable request bodies
  requestBodies:
    ...
  # Reusable responses, such as 401 Unauthorized or 400 Bad Request
  responses:
    ...
  # Reusable response headers
  headers:
    ...
  # Reusable examples
  examples:
    ...
  # Reusable links
  links:
    ...
  # Reusable callbacks
  callbacks:
    ...
```

So I fix it by adding `components` key into `data` `dict` in `base.py` with some validation. This will only consider when we change the `OpenApi` version to `3.*.*` and I would like to see them in the official repository. Thanks!