### PR TITLE
Fixing $ref when validating request.parsed_data (Flask RESTful)

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -586,12 +586,14 @@ class Swagger(object):
                 schemas = self.schemas[path_key]
             else:
                 doc = None
+                definitions = None
                 for spec in self.config['specs']:
                     apispec = self.get_apispecs(endpoint=spec['endpoint'])
                     if path in apispec['paths']:
                         if request.method.lower() in apispec['paths'][path]:
                             doc = apispec['paths'][path][
                                 request.method.lower()]
+                            definitions = apispec.get('definitions', {})
                             break
                 if not doc:
                     return
@@ -604,6 +606,7 @@ class Swagger(object):
                     location = self.SCHEMA_LOCATIONS[param['in']]
                     if location == 'json':  # load data from 'request.json'
                         schemas[location] = param['schema']
+                        schemas[location]['definitions'] = dict(definitions)  # don't want defaultdict for definitions
                     else:
                         name = param['name']
                         if location != 'path':

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -24,7 +24,6 @@ from flask import redirect
 from flask import render_template
 from flask import request, url_for
 from flask import abort
-from flask import Response
 from flask.views import MethodView
 from flask.json import JSONEncoder
 try:

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -638,7 +638,7 @@ class Swagger(object):
                         data, schemas[location],
                         format_checker=self.format_checker)
                 except jsonschema.ValidationError as e:
-                    abort(Response(e.message, status=400))
+                    abort(400, e.message)
 
             setattr(request, 'parsed_data', parsed_data)
 

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -606,7 +606,7 @@ class Swagger(object):
                     location = self.SCHEMA_LOCATIONS[param['in']]
                     if location == 'json':  # load data from 'request.json'
                         schemas[location] = param['schema']
-                        schemas[location]['definitions'] = dict(definitions)  # don't want defaultdict for definitions
+                        schemas[location]['definitions'] = dict(definitions)
                     else:
                         name = param['name']
                         if location != 'path':


### PR DESCRIPTION
Added definitions to parsed_data validation.

Previously only `properties` of the method on an endpoint are used for validation.
This adds `definitions` from apispec as well, so $ref is now handled correctly.

I believe this is a solution for #329