### PR TITLE
Enable import: syntax in template.yml

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -37,6 +37,7 @@ from .constants import OPTIONAL_FIELDS
 from .utils import extract_definitions
 from .utils import get_specs
 from .utils import get_schema_specs
+from .utils import parse_imports
 from .utils import parse_definition_docstring
 from .utils import get_vendor_extension_fields
 from .utils import validate
@@ -221,7 +222,7 @@ class Swagger(object):
         if filename.endswith('.json'):
             loader = json.load
         elif filename.endswith('.yml') or filename.endswith('.yaml'):
-            loader = yaml.safe_load
+            loader = lambda stream: yaml.safe_load(parse_imports(stream.read(), filename))
         else:
             with codecs.open(filename, 'r', 'utf-8') as f:
                 contents = f.read()
@@ -229,7 +230,7 @@ class Swagger(object):
                 if contents[0] in ['{', '[']:
                     loader = json.load
                 else:
-                    loader = yaml.safe_load
+                    loader = lambda stream: yaml.safe_load(parse_imports(stream.read(), filename))
         with codecs.open(filename, 'r', 'utf-8') as f:
             return loader(f)
 

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -222,7 +222,8 @@ class Swagger(object):
         if filename.endswith('.json'):
             loader = json.load
         elif filename.endswith('.yml') or filename.endswith('.yaml'):
-            loader = lambda stream: yaml.safe_load(parse_imports(stream.read(), filename))
+            loader = lambda stream: \
+                yaml.safe_load(parse_imports(stream.read(), filename))
         else:
             with codecs.open(filename, 'r', 'utf-8') as f:
                 contents = f.read()
@@ -230,7 +231,8 @@ class Swagger(object):
                 if contents[0] in ['{', '[']:
                     loader = json.load
                 else:
-                    loader = lambda stream: yaml.safe_load(parse_imports(stream.read(), filename))
+                    loader = lambda stream: \
+                        yaml.safe_load(parse_imports(stream.read(), filename))
         with codecs.open(filename, 'r', 'utf-8') as f:
             return loader(f)
 


### PR DESCRIPTION
I really appreciate the `import:` syntax in yaml files for avoiding large monolithic docs.

However, the syntax is currently supported in method or view docs and not available in `template.yml`.
I enabled the `import:` syntax also for the `template.yml` by injecting `parse_imports()` to `load_swagger_file()`.

I think this would improve the maintainability of docs and be nice improvement :)