### PR TITLE
Add example using multiple routes for a single function with blueprints

### DIFF
--- a/examples/example_blueprint.py
+++ b/examples/example_blueprint.py
@@ -48,6 +48,17 @@ def usernames2(username):
     return jsonify({'username': username})
 
 
+@example_blueprint.route('/users', endpoint='user-without-id', methods=['GET'])
+@example_blueprint.route('/users/<user_id>', endpoint='user-with-id', methods=['GET'])
+@swag_from('user_with_id_specs.yml', endpoint='example_blueprint.user-with-id', methods=['GET'])
+@swag_from('user_without_id_specs.yml', endpoint='example_blueprint.user-without-id', methods=['GET'])
+def usernames(user_id=None):
+    if user_id:
+        return jsonify({'user_id': user_id})
+    else:
+        return jsonify([])
+
+
 app.register_blueprint(example_blueprint)
 
 swag = Swagger(app)

--- a/examples/user_with_id_specs.yml
+++ b/examples/user_with_id_specs.yml
@@ -1,0 +1,25 @@
+This is the summary defined in yaml file
+Get single User endpoint
+---
+tags:
+  - users
+parameters:
+  - in: path
+    name: user_id
+    type: string
+    required: true
+definitions:
+  User:
+    type: object
+    properties:
+      user_id:
+        type: string
+      user_name:
+        type: string
+responses:
+  200:
+    description: A user matching the specified id
+    schema:
+      $ref: '#/definitions/User'
+    examples:
+      - {"user_id": "1234", "user_name": "Nicholai Hel"}

--- a/examples/user_without_id_specs.yml
+++ b/examples/user_without_id_specs.yml
@@ -1,0 +1,25 @@
+This is the summary defined in yaml file
+Get all Users endpoint
+---
+tags:
+  - users
+definitions:
+  User:
+    type: object
+    properties:
+      user_id:
+        type: string
+      user_name:
+        type: string
+  Users:
+    type: array
+    items:
+      $ref: '#/definitions/User'
+responses:
+  200:
+    description: A list of Users
+    schema:
+      $ref: '#/definitions/Users'
+    examples:
+      - [{"user_id": "1234", "user_name": "Nicholai Hel"}, {"user_id": "5678", "user_name": "Le Cagot"}]
+      - []


### PR DESCRIPTION
This PR adds an example for a common use case: using external spec files in conjunction with `blueprint`s.  In this situation the `endpoints` kwarg in `@swag_from` needs to be prefixed with the `blueprint` name.

Currently there are only examples for blueprints _or_ multiple routes, but no examples (or documentation that I could find) showing how they can be used in tandem.