### PR TITLE
Support Marshmallow Schemas in Function Based Views

### DIFF
--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -108,7 +108,10 @@ def get_specs(rules, ignore_verbs, optional_fields, sanitizer, doc_dir=None):
             swagged = False
 
             if getattr(method, 'specs_dict', None):
-                merge_specs(swag, deepcopy(method.specs_dict))
+                merge_specs(
+                    swag,
+                    convert_schemas(deepcopy(method.specs_dict))
+                )
                 swagged = True
 
             view_class = getattr(endpoint, 'view_class', None)

--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -108,10 +108,12 @@ def get_specs(rules, ignore_verbs, optional_fields, sanitizer, doc_dir=None):
             swagged = False
 
             if getattr(method, 'specs_dict', None):
+                definition = {}
                 merge_specs(
                     swag,
-                    convert_schemas(deepcopy(method.specs_dict))
+                    convert_schemas(deepcopy(method.specs_dict), definition)
                 )
+                swag['definitions'] = definition
                 swagged = True
 
             view_class = getattr(endpoint, 'view_class', None)


### PR DESCRIPTION
Currently this will not work as flasgger only supports using schemas in the `SwaggerView`. Not sure if this deliberate, or just that cool people don't use function based views (it was quite confusing that it didn't work with `swag_from`).

```
@views.route('/abc/', methods=['GET'])
@swag_from({
    'responses': {
        HTTPStatus.OK.value: {
            'schema': MySchema
        }
    }
})
def endpoint():
     ....
```

