### PR TITLE
Add oauth custom configuration

### DIFF
--- a/flasgger/ui3/templates/flasgger/swagger.html
+++ b/flasgger/ui3/templates/flasgger/swagger.html
@@ -64,6 +64,10 @@ window.onload = function() {
     
     )
 
+    {% if flasgger_config.oauth %}
+    ui.initOAuth({{ json.dumps(flasgger_config['oauth']) | safe }})
+    {%- endif %}
+    
     window.ui = ui
 
     {% if not flasgger_config.hide_top_bar -%}


### PR DESCRIPTION
Adding the ability to add OAuth configuration in the html template from flasgger config object.
Because it must be done with the instance method initOAuth() after `ui`initialization.