### PR TITLE
Fix #297: Forward validation_error_handler in Marshmallow APIspec

### DIFF
--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -64,6 +64,7 @@ class SwaggerView(MethodView):
     description = None
     validation = False
     validation_function = None
+    validation_error_handler = None
 
     def dispatch_request(self, *args, **kwargs):
         """
@@ -81,7 +82,9 @@ class SwaggerView(MethodView):
             specs.update(convert_schemas(specs, definitions))
             specs['definitions'] = definitions
             flasgger.utils.validate(
-                specs=specs, validation_function=self.validation_function)
+                specs=specs, validation_function=self.validation_function,
+                validation_error_handler=self.validation_error_handler
+            )
         return super(SwaggerView, self).dispatch_request(*args, **kwargs)
 
 


### PR DESCRIPTION
This fix was made by @allrod5 quite a while back, and it hopefully fixes the bug #297
I think this should be merged into the master branch.