### PR TITLE
permit configuring jwt header type and header name of intercept token

### DIFF
--- a/flasgger/ui2/templates/flasgger/index.html
+++ b/flasgger/ui2/templates/flasgger/index.html
@@ -78,7 +78,12 @@
           {% if config.JWT_AUTH_URL_RULE -%}
             $(document).find('div.response_headers').bind('DOMSubtreeModified', function(event) {
               var response = JSON.parse($(this).text());
-              var tokenField = 'jwt-token';
+              {% if config.JWT_AUTH_HEADER_TOKEN -%}
+                var jwtAuthHeaderToken = "{{ config.JWT_AUTH_HEADER_TOKEN }}";
+              {%- else %}
+                var jwtAuthHeaderToken = "jwt-token";
+              {%- endif %}
+              var tokenField = jwtAuthHeaderToken;
               if (response.hasOwnProperty(tokenField)) {
                 var jwt_token = response[tokenField];
                 {% if config.JWT_AUTH_HEADER_NAME -%}
@@ -86,7 +91,12 @@
                 {%- else %}
                   var jwtAuthHeaderName = "Authorization";
                 {%- endif %}
-                swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization(jwtAuthHeaderName, "Bearer " + jwt_token, "header"));
+                {% if config.JWT_AUTH_HEADER_TYPE -%}
+                  var jwtAuthHeaderType = "{{ config.JWT_AUTH_HEADER_TYPE }}";
+                {%- else %}
+                  var jwtAuthHeaderType = "Bearer";
+                {%- endif %}
+                swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization(jwtAuthHeaderName, jwtAuthHeaderType + " " + jwt_token, "header"));
               }
             });
           {%- endif %}

--- a/flasgger/ui3/templates/flasgger/swagger.html
+++ b/flasgger/ui3/templates/flasgger/swagger.html
@@ -35,13 +35,23 @@ window.onload = function() {
             {%- else %}
                 var jwtAuthHeaderName = "Authorization";
             {%- endif %}
-            request.headers[jwtAuthHeaderName] = "Bearer " + jwt_token;
+            {% if config.JWT_AUTH_HEADER_TYPE -%}
+                var jwtAuthHeaderType = "{{ config.JWT_AUTH_HEADER_TYPE }}";
+            {%- else %}
+                var jwtAuthHeaderType = "Bearer";
+            {%- endif %}
+            request.headers[jwtAuthHeaderName] = jwtAuthHeaderType + " " + jwt_token;
         }
 
         return request;
     },
     responseInterceptor: function(response) {
-        var tokenField = 'jwt-token';
+        {% if config.JWT_AUTH_HEADER_TOKEN -%}
+            var jwtAuthHeaderToken = "{{ config.JWT_AUTH_HEADER_TOKEN }}";
+        {%- else %}
+            var jwtAuthHeaderToken = "jwt-token";
+        {%- endif %}
+        var tokenField = jwtAuthHeaderToken;
         var headers = response.headers;
 
         if (headers.hasOwnProperty(tokenField)) {


### PR DESCRIPTION
possibility to modify token name and auth header type with config options:

- JWT_AUTH_HEADER_TOKEN
- JWT_AUTH_HEADER_TYPE

(the token must be in lowercase because response object seem to lowercase the headers )
 