### PR TITLE
Add OAuth2 html to flasgger routes

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -127,6 +127,7 @@ class OAuthRedirect(MethodView):
             ['flasgger/oauth2-redirect.html', 'flasgger/o2c.html'],
         )
 
+
 class APISpecsView(MethodView):
     """
     The /apispec_1.json and other specs
@@ -568,7 +569,11 @@ class Swagger(object):
                 ))
             )
 
-            redirect_default = specs_route + '/o2c.html' if uiversion < 3 else "/oauth2-redirect.html"
+            if uiversion < 3:
+                redirect_default = specs_route + '/o2c.html'
+            else:
+                redirect_default = "/oauth2-redirect.html"
+
             blueprint.add_url_rule(
                 self.config.get('oauth_redirect', redirect_default),
                 'oauth_redirect',

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -118,6 +118,15 @@ class APIDocsView(MethodView):
             )
 
 
+class OAuthRedirect(MethodView):
+    """
+    The OAuth2 redirect HTML for Swagger UI standard/implicit flow
+    """
+    def get(self):
+        return render_template(
+            ['flasgger/oauth2-redirect.html', 'flasgger/o2c.html'],
+        )
+
 class APISpecsView(MethodView):
     """
     The /apispec_1.json and other specs
@@ -549,12 +558,22 @@ class Swagger(object):
                 static_url_path=self.config.get('static_url_path', None)
             )
 
+            specs_route = self.config.get('specs_route', '/apidocs/')
             blueprint.add_url_rule(
-                self.config.get('specs_route', '/apidocs/'),
+                specs_route,
                 'apidocs',
                 view_func=wrap_view(APIDocsView().as_view(
                     'apidocs',
                     view_args=dict(config=self.config)
+                ))
+            )
+
+            redirect_default = specs_route + '/o2c.html' if uiversion < 3 else "/oauth2-redirect.html"
+            blueprint.add_url_rule(
+                self.config.get('oauth_redirect', redirect_default),
+                'oauth_redirect',
+                view_func=wrap_view(OAuthRedirect().as_view(
+                    'oauth_redirect'
                 ))
             )
 

--- a/flasgger/ui2/templates/flasgger/index.html
+++ b/flasgger/ui2/templates/flasgger/index.html
@@ -57,14 +57,8 @@
         supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function(swaggerApi, swaggerUi){
           if(typeof initOAuth == "function") {
-            initOAuth({
-              clientId: "your-client-id",
-              clientSecret: "your-client-secret-if-required",
-              realm: "your-realms",
-              appName: "your-app-name",
-              scopeSeparator: " ",
-              additionalQueryStringParams: {}
-            });
+              let oauth_config = {{ flasgger_config.get("auth") | safe }};
+              initOAuth(oauth_config);
           }
 
           if(window.SwaggerTranslator) {

--- a/flasgger/ui3/templates/flasgger/swagger.html
+++ b/flasgger/ui3/templates/flasgger/swagger.html
@@ -64,6 +64,10 @@ window.onload = function() {
     
     )
 
+    let auth_config = {{ flasgger_config.get("auth") | safe }};
+
+    ui.initOAuth(auth_config);
+
     window.ui = ui
 
     {% if not flasgger_config.hide_top_bar -%}


### PR DESCRIPTION
Even though the oauth2 redirect HTML is available in the template folders, there is no way to use them properly as they are not made available through Flask.
In this PR I made said HTML available through the blueprints as well as adding an "auth" configuration that can be read as the configuration for the Swagger UI ui.initOAuth to initialize it properly.