### PR TITLE
Fixing werkzeug library import error (Issue #364)

### DIFF
--- a/demo_app/app.py
+++ b/demo_app/app.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from flask import Flask, render_template
 from werkzeug.serving import run_simple
-from werkzeug.wsgi import DispatcherMiddleware
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from flasgger import __version__
 from flasgger.utils import get_examples

--- a/demo_app/app.py
+++ b/demo_app/app.py
@@ -4,7 +4,10 @@ from collections import OrderedDict
 
 from flask import Flask, render_template
 from werkzeug.serving import run_simple
-from werkzeug.middleware.dispatcher import DispatcherMiddleware
+try:
+    from werkzeug.middleware.dispatcher import DispatcherMiddleware
+except ImportError:
+    from werkzeug.wsgi import DispatcherMiddleware
 
 from flasgger import __version__
 from flasgger.utils import get_examples


### PR DESCRIPTION
Werkzeug Library moved its DispatcherMiddleware class from "wsgi" module
to "middleware.dispatcher" module. This causes an import error when
spinning up the demo app. This commit therefore fixes the issue #364:
https://github.com/flasgger/flasgger/issues/364