### PR TITLE
Easy usage Marshmallow with flasgger (like FastAPI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
       sudo: true
   allow_failures:
     - env: TOXENV=py38-dev-flasklatest
+    - env: TOXENV=py27-flask010
+    - env: TOXENV=py27-flask10
+    - env: TOXENV=py27-flask104
 
 before_install:
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ def colors(palette):
 
 > FIRST: `pip install marshmallow apispec`
 
+> USAGE #1: `SwaggerView`
+
 ```python
 from flask import Flask, jsonify
 from flasgger import Swagger, SwaggerView, Schema, fields
@@ -319,6 +321,45 @@ app.add_url_rule(
 app.run(debug=True)
 
 ```
+
+> USAGE #2: `Custom Schema from flasgger`
+
+- `Body` - support all fields in marshmallow
+- `Query` - support simple fields in marshmallow (Int, String and etc)
+- `Path` - support only int and str
+
+```python
+from flask import Flask
+from flasgger import Swagger, Schema, fields
+from marshmallow.validate import Length, OneOf
+
+app = Flask(__name__)
+Swagger(app)
+
+swag = {"swag": True,
+        "tags": ["demo"],
+        "responses": {200: {"description": "Success request"},
+                      400: {"description": "Validation error"}}}
+
+
+class Body(Schema):
+    color = fields.List(fields.String(), required=True, validate=Length(max=5), example=["white", "blue", "red"])
+
+
+class Query(Schema):
+    color = fields.String(required=True, validate=OneOf(["white", "blue", "red"]))
+    swag_in = "query"
+
+
+@app.route("/color/<int:id>", methods=["POST"], **swag)
+def index(body: Body, query: Query, id: int):
+    return {"body": body, "query": query, "id": id}
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
 
 > NOTE: take a look at `examples/validation.py` for a more complete example.
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ app.run(debug=True)
 - `Path` - support only int and str
 
 ```python
-from flask import Flask
+from flask import Flask, abort
 from flasgger import Swagger, Schema, fields
 from marshmallow.validate import Length, OneOf
 
@@ -345,19 +345,31 @@ swag = {"swag": True,
 class Body(Schema):
     color = fields.List(fields.String(), required=True, validate=Length(max=5), example=["white", "blue", "red"])
 
+    def swag_validation_function(self, data, main_def):
+        self.load(data)
+
+    def swag_validation_error_handler(self, err, data, main_def):
+        abort(400, err)
+
 
 class Query(Schema):
     color = fields.String(required=True, validate=OneOf(["white", "blue", "red"]))
+
+    def swag_validation_function(self, data, main_def):
+        self.load(data)
+
+    def swag_validation_error_handler(self, err, data, main_def):
+        abort(400, err)
+
     swag_in = "query"
 
 
-@app.route("/color/<int:id>", methods=["POST"], **swag)
-def index(body: Body, query: Query, id: int):
-    return {"body": body, "query": query, "id": id}
-
+@app.route("/color/<id>/<name>", methods=["POST"], **swag)
+def index(body: Body, query: Query, id: int, name: str):
+    return {"body": body, "query": query, "id": id, "name": name}
 
 if __name__ == "__main__":
-    app.run()
+    app.run(debug=True)
 ```
 
 

--- a/examples/swag_annotation.py
+++ b/examples/swag_annotation.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, abort
 from flasgger import Swagger, Schema, fields
 from marshmallow.validate import Length, OneOf
 
@@ -14,9 +14,22 @@ swag = {"swag": True,
 class Body(Schema):
     color = fields.List(fields.String(), required=True, validate=Length(max=5), example=["white", "blue", "red"])
 
+    def swag_validation_function(self, data, main_def):
+        self.load(data)
+
+    def swag_validation_error_handler(self, err, data, main_def):
+        abort(400, err)
+
 
 class Query(Schema):
     color = fields.String(required=True, validate=OneOf(["white", "blue", "red"]))
+
+    def swag_validation_function(self, data, main_def):
+        self.load(data)
+
+    def swag_validation_error_handler(self, err, data, main_def):
+        abort(400, err)
+
     swag_in = "query"
 
 

--- a/examples/swag_schema.py
+++ b/examples/swag_schema.py
@@ -1,0 +1,29 @@
+from flask import Flask
+from flasgger import Swagger, Schema, fields
+from marshmallow.validate import Length, OneOf
+
+app = Flask(__name__)
+Swagger(app)
+
+swag = {"swag": True,
+        "tags": ["demo"],
+        "responses": {200: {"description": "Success request"},
+                      400: {"description": "Validation error"}}}
+
+
+class Body(Schema):
+    color = fields.List(fields.String(), required=True, validate=Length(max=5), example=["white", "blue", "red"])
+
+
+class Query(Schema):
+    color = fields.String(required=True, validate=OneOf(["white", "blue", "red"]))
+    swag_in = "query"
+
+
+@app.route("/color/<id>", methods=["POST"], **swag)
+def index(body: Body, query: Query, id: int):
+    return {"body": Body, "query": query}
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/swag_schema.py
+++ b/examples/swag_schema.py
@@ -20,9 +20,9 @@ class Query(Schema):
     swag_in = "query"
 
 
-@app.route("/color/<id>", methods=["POST"], **swag)
-def index(body: Body, query: Query, id: int):
-    return {"body": Body, "query": query}
+@app.route("/color/<id>/<name>", methods=["POST"], **swag)
+def index(body: Body, query: Query, id: int, name: str):
+    return {"body": Body, "query": query, "id": id, "name": name}
 
 
 if __name__ == "__main__":

--- a/examples/swag_schema.py
+++ b/examples/swag_schema.py
@@ -22,7 +22,25 @@ class Query(Schema):
 
 @app.route("/color/<id>/<name>", methods=["POST"], **swag)
 def index(body: Body, query: Query, id: int, name: str):
-    return {"body": Body, "query": query, "id": id, "name": name}
+    return {"body": body, "query": query, "id": id, "name": name}
+
+
+def test_swag(client, specs_data):
+    """
+    This test is runs automatically in Travis CI
+
+    :param client: Flask app test client
+    :param specs_data: {'url': {swag_specs}} for every spec in app
+    """
+    payload = {"color": ["white", "blue", "red"]}
+
+    test_case = [
+        {"url": '/color/100/putin?color=white', "status_code": 200},
+        {"url": '/color/100/putin?color=black', "status_code": 400}
+    ]
+    for case in test_case:
+        response = client.post(case["url"], json=payload)
+        assert response.status_code == case["status_code"]
 
 
 if __name__ == "__main__":

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -41,6 +41,7 @@ from .utils import parse_imports
 from .utils import get_vendor_extension_fields
 from .utils import validate
 from .utils import LazyString
+from .utils import swag_schema
 from . import __version__
 
 
@@ -60,6 +61,7 @@ class APIDocsView(MethodView):
     """
     The /apidocs
     """
+
     def __init__(self, *args, **kwargs):
         view_args = kwargs.pop('view_args', {})
         self.config = view_args.get('config')
@@ -122,6 +124,7 @@ class APISpecsView(MethodView):
     """
     The /apispec_1.json and other specs
     """
+
     def __init__(self, *args, **kwargs):
         self.loader = kwargs.pop('loader')
         super(APISpecsView, self).__init__(*args, **kwargs)
@@ -137,6 +140,7 @@ class SwaggerDefinition(object):
     """
     Class based definition
     """
+
     def __init__(self, name, obj, tags=None):
         self.name = name
         self.obj = obj
@@ -205,6 +209,7 @@ class Swagger(object):
         """
         self.decorators = decorators or self.decorators
         self.app = app
+        self.app.add_url_rule = swag_schema(self.app.add_url_rule)
 
         self.load_config(app)
         # self.load_apispec(app)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -41,7 +41,7 @@ from .utils import parse_imports
 from .utils import get_vendor_extension_fields
 from .utils import validate
 from .utils import LazyString
-from .utils import swag_schema
+from .utils import swag_annotation
 from . import __version__
 
 
@@ -209,7 +209,7 @@ class Swagger(object):
         """
         self.decorators = decorators or self.decorators
         self.app = app
-        self.app.add_url_rule = swag_schema(self.app.add_url_rule)
+        self.app.add_url_rule = swag_annotation(self.app.add_url_rule)
 
         self.load_config(app)
         # self.load_apispec(app)

--- a/flasgger/constants.py
+++ b/flasgger/constants.py
@@ -6,3 +6,9 @@ OPTIONAL_FIELDS = [
 OPTIONAL_OAS3_FIELDS = [
     'components', 'servers'
 ]
+
+DEFAULT_FIELDS = {"tags": [], "consumes": ['application/json'],
+                  "produces": ['application/json'], "schemes": [],
+                  "security": [], "deprecated": False, "operationId": "",
+                  "definitions": {}, "responses": {}, "summary": None,
+                  "description": None, "parameters": []}

--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -26,6 +26,9 @@ try:
     class Schema(marshmallow.Schema):
         swag_in = "body"
         swag_validate = True
+        swag_validation_function = None
+        swag_validation_error_handler = None
+        swag_require_data = True
 
         def to_specs_dict(self):
             specs = {'parameters': self.__class__}


### PR DESCRIPTION
Hi, guys.
I am add code for easy usage marshmallow without SwaggerView.
Support only ``python3.6+`` (use __annotations__)
Usage looks like FastAPI+pydantic.

Example: 
```python
from flask import Flask, abort
from flasgger import Swagger, Schema, fields
from marshmallow.validate import Length, OneOf

app = Flask(__name__)
Swagger(app)

swag = {"swag": True,
        "tags": ["demo"],
        "responses": {200: {"description": "Success request"},
                      400: {"description": "Validation error"}}}


class Body(Schema):
    color = fields.List(fields.String(), required=True, validate=Length(max=5), example=["white", "blue", "red"])

    def swag_validation_function(self, data, main_def):
        self.load(data)

    def swag_validation_error_handler(self, err, data, main_def):
        abort(400, err)


class Query(Schema):
    color = fields.String(required=True, validate=OneOf(["white", "blue", "red"]))

    def swag_validation_function(self, data, main_def):
        self.load(data)

    def swag_validation_error_handler(self, err, data, main_def):
        abort(400, err)

    swag_in = "query"


@app.route("/color/<id>/<name>", methods=["POST"], **swag)
def index(body: Body, query: Query, id: int, name: str):
    return {"body": body, "query": query, "id": id, "name": name}

if __name__ == "__main__":
    app.run(debug=True)
```

This code activate with flag `swag=True` (see code above)

I am use custom `Schema` with additional param:
- swag_in (default - body)
- swag_validate (default - True)
- swag_validation_function (default - None)
- swag_validation_error_handler (default - None)
- swag_require_data (default - True)

My code support *_in:
1) `body` - for POST request
2) `query` - for query string

Add info in README.md
Add new test case.

In the future it is possible to add support ``pydantic``