### PR TITLE
Fix definition docstring splitting

### DIFF
--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -683,7 +683,7 @@ def parse_definition_docstring(obj, process_doc):
         if yaml_sep != -1:
             doc_lines = process_doc(
                 full_doc[:yaml_sep - 1]
-            )
+            ) if yaml_sep else None
             swag = yaml.safe_load(full_doc[yaml_sep:])
         else:
             doc_lines = process_doc(full_doc)


### PR DESCRIPTION
**To reproduce:**

```python
@swagger.definition('Foo')
class Foo:
    """
    ---
    type: string
```

**Expected:** definition with no description.

```
definitions:
  Foo:
    type: string
```

**Actual:** the whole docstring except last character is duplicated in the description.

```
definitions:
  Foo:
    description: |
      ---
      type: strin
    type: string
```

**Cause:** `parse_definition_docstring` goes basically like this:

```python
full_doc = inspect.getdoc(obj)
# inspect.getdoc strips all leading whitespace,
# so full_doc starts with ---
yaml_sep = full_doc.find('---')  # this is 0
if yaml_sep != -1:
    doc_lines = process_doc(
        full_doc[:yaml_sep - 1]
        # this is full_doc[:-1],
        # that is, the whole string except last character
    )
```