### PR TITLE
Deprecate imp [Breaks py2.7 compatibility]

### DIFF
--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -2,7 +2,7 @@
 
 import codecs
 import copy
-import imp
+import importlib
 import inspect
 import os
 import re
@@ -565,7 +565,7 @@ def load_from_file(swag_path, swag_type='yml', root_path=None):
             path = swag_path.replace(
                 (root_path or os.path.dirname(__file__)), ''
             ).split(os.sep)[1:]
-            site_package = imp.find_module(path[0])[1]
+            site_package = importlib.abc.PathEntryFinder.find_module(path[0])[1]
             swag_path = os.path.join(site_package, os.sep.join(path[1:]))
             with open(swag_path) as yaml_file:
                 return yaml_file.read()

--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -565,7 +565,13 @@ def load_from_file(swag_path, swag_type='yml', root_path=None):
             path = swag_path.replace(
                 (root_path or os.path.dirname(__file__)), ''
             ).split(os.sep)[1:]
-            site_package = importlib.abc.PathEntryFinder.find_module(path[0])[1]
+            package_spec = importlib.util.find_spec(path[0])
+            if package_spec.has_location:
+                # Improvement idea: Use package_spec.submodule_search_locations
+                # if we're sure there's only going to be one search location.
+                site_package = package_spec.origin.replace('/__init__.py', '')
+            else:
+                raise RuntimeError("Package does not have origin")
             swag_path = os.path.join(site_package, os.sep.join(path[1:]))
             with open(swag_path) as yaml_file:
                 return yaml_file.read()


### PR DESCRIPTION
Getting the following warnings:
```
venv/lib/python3.7/site-packages/flasgger/utils.py:5
 
venv/lib/python3.7/site-packages/flasgger/utils.py:5: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
 
    import imp

-- Docs: https://docs.pytest.org/en/latest/warnings.html

```

I guess this relates to https://github.com/flasgger/flasgger/issues/399 , but I think since Python2 has officially reached the EOL, this makes sense.  

**This makes this package incompatible with Python < 3.3**