### PR TITLE
fix root_path of load_swagger_file

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -251,7 +251,7 @@ class Swagger(object):
             loader = json.load
         elif filename.endswith('.yml') or filename.endswith('.yaml'):
             loader = lambda stream: \
-                yaml.safe_load(parse_imports(stream.read(), filename))
+                yaml.safe_load(parse_imports(stream.read(), self.config.get('doc_dir')))
         else:
             with codecs.open(filename, 'r', 'utf-8') as f:
                 contents = f.read()
@@ -260,7 +260,7 @@ class Swagger(object):
                     loader = json.load
                 else:
                     loader = lambda stream: \
-                        yaml.safe_load(parse_imports(stream.read(), filename))
+                        yaml.safe_load(parse_imports(stream.read(), self.config.get('doc_dir')))
         with codecs.open(filename, 'r', 'utf-8') as f:
             return loader(f)
 


### PR DESCRIPTION
Given thing_doer.yml:

```
tags:
  - "thing_doer"
summary: "Do a thing"
description: ""
consumes:
  - "application/json"
produces:
  - "application/json"
parameters:
  - in: "body"
    name: "body"
    required: true
    schema:
      import: "models/stuff.yml"
responses:
  200:
    description: "The results of doing a thing"
    schema:
      type: "object"
      properties:
        whatever:
          type: "integer"
```
with a file structure as follows, the folder `specs` is the `doc_dir`:
```
specs/
   thing_doer.yml
   models/
      stuff.yml
```
before this fix:
the stuff.yml full path would be `specs/thing_doer.yml/models/stuff.yml`, and it's wrong.

after this fix:
the stuff.yml full path would be `specs/models/stuff.yml`, and it's right.

