### PR TITLE
Remove top-level definitions key for openapi 3 specs

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -532,6 +532,8 @@ class Swagger(object):
                     else:
                         paths[srule][key] = val
         self.apispecs[endpoint] = data
+        if is_openapi3():
+            del data['definitions']
         return data
 
     def definition(self, name, tags=None):


### PR DESCRIPTION
This PR implements a hacky fix for #267 (as mentioned in that issue, something similar has been done in [this fork](https://github.com/IKNL/flasgger/) ). Possibly as a separate PR, i'd be happy to dust up the tests and to add https://github.com/p1c2u/openapi-spec-validator to the test suite to check this behaviour remains fixed going forward.