### PR TITLE
fix auth_header_value and auth_header_prefix value in calling jwt_req…

### DIFF
--- a/examples/jwt_auth.py
+++ b/examples/jwt_auth.py
@@ -75,11 +75,12 @@ app.config["SWAGGER"] = {
     "uiversion": 3,
 }
 app.config['JWT_AUTH_URL_RULE'] = '/api/auth'
-app.config['JWT_AUTH_HEADER_NAME'] = 'JWTAuthorization'
+app.config['JWT_AUTH_HEADER_NAME'] = 'Jwtauthorization'
+app.config['JWT_AUTH_HEADER_PREFIX'] = 'Bearer'
 
 swag = Swagger(app,
     template={
-        "openapi": "3.0.0",
+        "swagger": "2.0.0",
         "info": {
             "title": "Swagger Basic Auth App",
             "version": "1.0",


### PR DESCRIPTION
Revise auth_header_value and auth_header_prefix value, so the JWT_Auth.py example can work 