### PR TITLE
Implemented the SwaggerUI urls config parameter which displays a specs dropdown

### DIFF
--- a/examples/multiple_specs_dropdown_example.py
+++ b/examples/multiple_specs_dropdown_example.py
@@ -1,0 +1,81 @@
+"""
+In this example a spec name is provided in order to trigger SwaggeUI's dropdown list of specs.
+"""
+from flask import Flask, jsonify
+try:
+    from http import HTTPStatus
+except ImportError:
+    import httplib as HTTPStatus
+from flasgger import Swagger
+from flasgger.utils import swag_from
+
+
+swagger_config = {
+    "headers": [
+    ],
+    "specs": [
+        {
+            "version": "0.0.1",
+            "title": "Api v1",
+            "name": "v1",
+            "endpoint": 'v1_spec',
+            "description": 'This is the version 1 of our API',
+            "route": '/v1/spec',
+            "rule_filter": lambda rule: rule.rule.startswith('/v1/'),
+        },
+        {
+            "version": "0.0.2",
+            "title": "Api v2",
+            "name": "v2",
+            "description": 'This is the version 2 of our API',
+            "endpoint": 'v2_spec',
+            "route": '/v2/spec',
+            "rule_filter": lambda rule: rule.rule.startswith('/v2/'),
+        }
+    ],
+    "static_url_path": "/flasgger_static",
+}
+
+app = Flask(__name__)
+swag = Swagger(app, config=swagger_config)
+
+
+
+@app.route('/v1/hello')
+def v1_hello():
+    """
+    A test view
+
+    ---
+    responses:
+      200:
+        description: OK
+    """
+    return jsonify(hello="world")
+
+
+@app.route('/v2/hello')
+def v2_hello():
+    """
+    A test view v2
+
+    ---
+    responses:
+      200:
+        description: OK
+    """
+    return jsonify(hello="world")
+
+
+def test_swag(client, specs_data):
+    """
+    This test is runs automatically in Travis CI
+
+    :param client: Flask app test client
+    :param specs_data: {'url': {swag_specs}} for every spec in app
+    """
+    assert client.get('/apidocs/').status_code == HTTPStatus.OK
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -78,13 +78,22 @@ class APIDocsView(MethodView):
             {
                 "url": url_for(".".join((base_endpoint, spec['endpoint']))),
                 "title": spec.get('title', 'API Spec 1'),
+                "name": spec.get('name', None),
                 "version": spec.get("version", '0.0.1'),
                 "endpoint": spec.get('endpoint')
             }
             for spec in self.config.get('specs', [])
         ]
+        urls = [
+            {
+                "name": spec["name"],
+                "url": spec["url"]
+            }
+            for spec in specs if spec["name"]
+        ]
         data = {
             "specs": specs,
+            "urls": urls,
             "title": self.config.get('title', 'Flasgger')
         }
         if request.args.get('json'):

--- a/flasgger/ui3/templates/flasgger/swagger.html
+++ b/flasgger/ui3/templates/flasgger/swagger.html
@@ -11,7 +11,11 @@ window.onload = function() {
     Object.assign(
     {
 
+    {% if urls %}
+    urls: {{ urls | tojson }},
+    {% else %}
     url: "{{ specs[0]['url'] }}",
+    {% endif %}
     dom_id: '#swagger-ui',
     validatorUrl: null,
     displayOperationId: true,


### PR DESCRIPTION
When the [urls](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#core) parameter is specified in the SwaggerUI config, a dropdown of API specs is displayed instead of an editable textbox. This can greatly help organize the multiple specs in a project, as suggested in this [StackOverflow answer](https://stackoverflow.com/a/45161533).

This behavior is currently triggered by simply adding a `name` parameter to the specs object, e.g.:
```json
{
    "specs": [
        {
            "version": "0.0.1",
            "title": "Api v1",
            "name": "v1",
            "endpoint": "v1_spec",
            "description": "This is the version 1 of our API"
        }
    ]
}
```

When this parameter is not included in the specs object, the editable textbox is displayed as usual. It might be more intuitive to have this behavior triggered by an external flag or something, but I'm not sure how this interface would look like.

Let me know if you have any ideas for this!