### PR TITLE
Fix required body if one parameter is required

### DIFF
--- a/examples/apispec_example.py
+++ b/examples/apispec_example.py
@@ -49,11 +49,32 @@ def random_pet():
     pet = {'category': [{'id': 1, 'name': 'rodent'}], 'name': 'Mickey'}
     return jsonify(PetSchema().dump(pet).data)
 
+@app.route("/add", methods=["POST"])
+def create_pet(body: PetSchema) :
+    """Create a cute furry animal endpoint.
+    ---
+    post:
+      description: Create a random pet
+      parameters: 
+        - in: body
+          schema: PetSchema
+      security:
+        - ApiKeyAuth: []
+      responses:
+        200:
+          content:
+            application/json:
+              schema: PetSchema
+    """
+    return jsonify(
+        {"data": body, "status": "New user created"}
+    ), 201
+
 
 template = spec.to_flasgger(
     app,
     definitions=[CategorySchema, PetSchema],
-    paths=[random_pet]
+    paths=[random_pet, create_pet]
 )
 
 """

--- a/examples/apispec_example.py
+++ b/examples/apispec_example.py
@@ -57,14 +57,18 @@ def create_pet(body: PetSchema) :
       description: Create a random pet
       parameters: 
         - in: body
-          schema: PetSchema
+          name: body
+          required: True
+          schema:
+                $ref: '#/definitions/Pet'
       security:
         - ApiKeyAuth: []
       responses:
-        200:
+        201:
+          description: If pet is created
           content:
             application/json:
-              schema: PetSchema
+              status: string
     """
     return jsonify(
         {"status": "New user created"}
@@ -86,7 +90,7 @@ template = apispec_to_template(
     app=app,
     spec=spec,
     definitions=[CategorySchema, PetSchema],
-    paths=[random_pet]
+    paths=[random_pet, create_pet]
 )
 
 """

--- a/examples/apispec_example.py
+++ b/examples/apispec_example.py
@@ -67,7 +67,7 @@ def create_pet(body: PetSchema) :
               schema: PetSchema
     """
     return jsonify(
-        {"data": body, "status": "New user created"}
+        {"status": "New user created"}
     ), 201
 
 

--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -144,6 +144,8 @@ def convert_schemas(d, definitions=None):
             if k == 'parameters':
                 new[k] = schema2parameters(v, location=v.swag_in)
                 new[k][0]['schema'] = ref
+                if len(definitions[v.__name__]['required']) != 0:
+                    new[k][0]['required'] = True
             else:
                 new[k] = ref
         else:


### PR DESCRIPTION
Hello,

When Flasgger is used with marshmallow and custom schema, the issue concerns the requirement of the body. Currently, the body is not required if at least one parameter (of the body) is required. This is the patch of this issue.

For example, my application has one endpoint to create an user: "/v1/pcc/{pcc_uid}/user" with a body parameter which is a UserSchema. One parameter in this schema is required, but body is not required.
Flasgger generates this JSON:
```
{
  "basePath": "/adduser_python_admin",
  "definitions": {
    "UserSchema": {
      "properties": {
        "email": {
          "format": "email",
          "type": "string"
        },
        "firstName": {
          "type": "string"
        },
        "lastName": {
          "type": "string"
        },
        "shortName": {
          "type": "string"
        }
      },
      "required": [
        "shortName"
      ],
      "type": "object"
    },
    "user.Credentials": {
      "properties": {
        "otpSecret": {
          "description": "OTP",
          "type": "string"
        },
        "password": {
          "description": "password",
          "type": "string"
        }
      }
    },
    "user.Id": {
      "properties": {
        "userId": {
          "description": "Id of created user",
          "type": "integer"
        }
      }
    },
    "user.State": {
      "properties": {
        "state": {
          "description": "wanted state",
          "type": "string"
        }
      }
    }
  },
  "info": {
  },
  "paths": {
   "/v1/pcc/{pcc_uid}/user": {
      "post": {
        "consumes": [
          "application/json"
        ],
        "deprecated": false,
        "description": "Create an user for a PCC",
        "operationId": "admin.createUser",
        "parameters": [
          {
            "in": "body",
            "name": "body",
            "required": false,
            "schema": {
              "$ref": "#/definitions/UserSchema"
            }
          },
          {
            "in": "path",
            "name": "pcc_uid",
            "required": true,
            "type": "string"
          }
        ],
        "produces": [
          "application/json"
        ],
        "responses": {
          "201": {
            "description": "Success request",
            "schema": {
              "$ref": "#/definitions/user.Id"
            }
          },
          "400": {
            "description": "Validation error"
          }
        },
        "schemes": [],
        "security": [],
        "summary": "Create the user ",
        "tags": [
          "admin"
        ]
      }
    }
  },
  "swagger": "2.0"
}
```

The important part is *"required": false* in:
```
        "operationId": "admin.createUser",
        "parameters": [
          {
            "in": "body",
            "name": "body",
            "required": false,
            "schema": {
              "$ref": "#/definitions/UserSchema"
            }
```

It normally should be *"required": true* because one parameter of UserSchema is required.

Regards,
Cédric.