### PR TITLE
fix path parameter bug for integers

### DIFF
--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -972,10 +972,17 @@ def swag_annotation(f):
                 function = validate_annotation(annotation, variable)(function)
 
             elif issubclass(annotation, int):
-                specs["parameters"].append({"name": variable,
-                                            "in": "path",
-                                            "type": "integer",
-                                            "required": True})
+                if ("int(signed=True):" + variable) in args[0]:
+                    specs["parameters"].append({"name": variable,
+                                                "in": "path",
+                                                "type": "integer",
+                                                "required": True})
+                else:
+                    specs["parameters"].append({"name": variable,
+                                                "in": "path",
+                                                "type": "integer",
+                                                "minimum": "0",
+                                                "required": True})
 
             elif issubclass(annotation, str):
                 specs["parameters"].append({"name": variable,


### PR DESCRIPTION
Hello,

According to [Flask documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#variable-rules), "int" in decorator means positive values. Current code is for the case "int(signed=True)". 
So, I have fixed this issue with this PR.