### PR TITLE
Spelling: Change `cian` to `cyan`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ def colors(palette):
           rgb: ['red', 'green', 'blue']
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':
@@ -332,7 +332,7 @@ class PaletteView(SwaggerView):
         This example is using marshmallow schemas
         """
         all_colors = {
-            'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+            'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
             'rgb': ['red', 'green', 'blue']
         }
         if palette == 'all':
@@ -898,7 +898,7 @@ def colors(palette):
           rgb: ['red', 'green', 'blue']
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/README.zh.md
+++ b/README.zh.md
@@ -110,7 +110,7 @@ def colors(palette):
           rgb: ['red', 'green', 'blue']
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':
@@ -299,7 +299,7 @@ class PaletteView(SwaggerView):
         This example is using marshmallow schemas
         """
         all_colors = {
-            'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+            'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
             'rgb': ['red', 'green', 'blue']
         }
         if palette == 'all':
@@ -813,7 +813,7 @@ def colors(palette):
           rgb: ['red', 'green', 'blue']
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/colors.py
+++ b/examples/colors.py
@@ -61,7 +61,7 @@ def colors(palette):
           rgb: ['red', 'green', 'blue']
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/colors_external_js.py
+++ b/examples/colors_external_js.py
@@ -65,7 +65,7 @@ def colors(palette):
           rgb: ['red', 'green', 'blue']
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/colors_from_specdict.py
+++ b/examples/colors_from_specdict.py
@@ -102,7 +102,7 @@ def colors(palette):
     deprecated: true
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/colors_template_json.py
+++ b/examples/colors_template_json.py
@@ -25,7 +25,7 @@ def colors(palette):
     deprecated: true
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/colors_template_yaml.py
+++ b/examples/colors_template_yaml.py
@@ -25,7 +25,7 @@ def colors(palette):
     deprecated: true
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/colors_uiversion2.py
+++ b/examples/colors_uiversion2.py
@@ -62,7 +62,7 @@ def colors(palette):
           rgb: ['red', 'green', 'blue']
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/colors_with_schema.py
+++ b/examples/colors_with_schema.py
@@ -41,7 +41,7 @@ class PaletteView(SwaggerView):
         This example is using marshmallow schemas
         """
         all_colors = {
-            'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+            'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
             'rgb': ['red', 'green', 'blue']
         }
         if palette == 'all':

--- a/examples/lazy_string.py
+++ b/examples/lazy_string.py
@@ -78,7 +78,7 @@ def colors(palette):
           rgb: ['red', 'green', 'blue']
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/swagger_config_2.py
+++ b/examples/swagger_config_2.py
@@ -118,7 +118,7 @@ def colors(palette):
     # values here overrides the specs dict
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':

--- a/examples/swagger_config_merge.py
+++ b/examples/swagger_config_merge.py
@@ -116,7 +116,7 @@ def colors(palette):
     # values here overrides the specs dict
     """
     all_colors = {
-        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
         'rgb': ['red', 'green', 'blue']
     }
     if palette == 'all':


### PR DESCRIPTION
The documentation uses `cian`, proper spelling is `cyan`.