### PR TITLE
Fix marshmallow OpenAPI 3.x.x support.

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -734,7 +734,7 @@ class Swagger(object):
                 parsed_data['json'] = request.json or {}
             for location, data in parsed_data.items():
                 try:
-                    ret = self.validation_function(data, schemas[location])
+                    self.validation_function(data, schemas[location])
                 except jsonschema.ValidationError as e:
                     self.validation_error_handler(e, data, schemas[location])
 

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -735,7 +735,6 @@ class Swagger(object):
             for location, data in parsed_data.items():
                 try:
                     ret = self.validation_function(data, schemas[location])
-                    print(ret)
                 except jsonschema.ValidationError as e:
                     self.validation_error_handler(e, data, schemas[location])
 

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -745,6 +745,30 @@ class Swagger(object):
         '''
         Schemas and parsers would be updated here from doc
         '''
+        for param in doc.get('parameters', []):
+            location = self.SCHEMA_LOCATIONS[param['in']]
+            if location == 'json':  # load data from 'request.json'
+                schemas[location] = param['schema']
+                self.set_schemas(schemas, location, definitions)
+            else:
+                name = param['name']
+                if location != 'path':
+                    parsers[location].add_argument(
+                        name,
+                        type=self.SCHEMA_TYPES[
+                            param['schema'].get('type', None)
+                            if 'schema' in param
+                            else param.get('type', None)],
+                        required=param.get('required', False),
+                        location=self.SCHEMA_LOCATIONS[
+                            param['in']],
+                        store_missing=False)
+
+                for k in param:
+                    if k != 'required':
+                        schemas[
+                            location]['properties'][name][k] = param[k]
+
         if self.is_openapi3():
             # 'json' to comply with self.SCHEMA_LOCATIONS's {'body':'json'}
             location = 'json'
@@ -776,31 +800,6 @@ class Swagger(object):
 
                 schemas[location] = json_schema
                 self.set_schemas(schemas, location, definitions)
-
-        else:  # openapi2
-            for param in doc.get('parameters', []):
-                location = self.SCHEMA_LOCATIONS[param['in']]
-                if location == 'json':  # load data from 'request.json'
-                    schemas[location] = param['schema']
-                    self.set_schemas(schemas, location, definitions)
-                else:
-                    name = param['name']
-                    if location != 'path':
-                        parsers[location].add_argument(
-                            name,
-                            type=self.SCHEMA_TYPES[
-                                param['schema'].get('type', None)
-                                if 'schema' in param
-                                else param.get('type', None)],
-                            required=param.get('required', False),
-                            location=self.SCHEMA_LOCATIONS[
-                                param['in']],
-                            store_missing=False)
-
-                    for k in param:
-                        if k != 'required':
-                            schemas[
-                                location]['properties'][name][k] = param[k]
 
     def set_schemas(self, schemas: dict, location: str,
                     definitions: dict):

--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -53,9 +53,9 @@ except ImportError:
 
 def check_openapi_version():
     if (
-        not current_app
-        or not hasattr(current_app, 'swag')
-        or getattr(openapi_converter, 'configured', False)
+        not current_app or not hasattr(
+            current_app, 'swag'
+        ) or getattr(openapi_converter, 'configured', False)
     ):
         return
     openapi_converter.openapi_version = OpenAPIVersion(

--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -1,14 +1,20 @@
 # coding: utf-8
 import inspect
 
+from flask import current_app
 from flask.views import MethodView
 
 import flasgger
+
+
+DEFAULT_OPENAPI_VERSION = '2.0'
+
 
 try:
     import marshmallow
     from marshmallow import fields
     from apispec.ext.marshmallow import openapi
+    from apispec.utils import OpenAPIVersion
     from apispec import APISpec as BaseAPISpec
 
     # Note that openapi_converter is initialized with trivial
@@ -16,7 +22,7 @@ try:
     #   supported for now. See issue #314 .
     # Also see: https://github.com/marshmallow-code/apispec/pull/447
     openapi_converter = openapi.OpenAPIConverter(
-        openapi_version='2.0',
+        openapi_version=DEFAULT_OPENAPI_VERSION,
         schema_name_resolver=lambda schema: None,
         spec=None
     )
@@ -43,6 +49,19 @@ except ImportError:
     schema2jsonschema = lambda schema: {}  # noqa
     schema2parameters = lambda schema, location: []  # noqa
     BaseAPISpec = object
+
+
+def check_openapi_version():
+    if (
+        not current_app
+        or not hasattr(current_app, 'swag')
+        or getattr(openapi_converter, 'configured', False)
+    ):
+        return
+    openapi_converter.openapi_version = OpenAPIVersion(
+        current_app.swag.config.get('openapi', DEFAULT_OPENAPI_VERSION)
+    )
+    openapi_converter.configured = True
 
 
 class APISpec(BaseAPISpec):
@@ -116,6 +135,8 @@ def convert_schemas(d, definitions=None):
     Also updates the optional definitions argument with any definitions
     entries contained within the schema.
     """
+    check_openapi_version()
+
     if definitions is None:
         definitions = {}
     definitions.update(d.get('definitions', {}))
@@ -139,7 +160,13 @@ def convert_schemas(d, definitions=None):
 
             definitions[v.__name__] = schema2jsonschema(v)
             ref = {
-                "$ref": "#/definitions/{0}".format(v.__name__)
+                "$ref": (
+                    "#/components/schemas/{0}".format(v.__name__)
+                    if flasgger.utils.is_openapi3(
+                        openapi_converter.openapi_version
+                    ) else
+                    "#/definitions/{0}".format(v.__name__)
+                )
             }
             if k == 'parameters':
                 new[k] = schema2parameters(v, location=v.swag_in)


### PR DESCRIPTION
There were some hardcoded variables in `flasgger/marshmallow_apispec.py` so it won't work with openapi 3.x.x standart correctly even if version was specified for `Swagger` object and just generated wrong `$refs` (e.g. `#/definitions/...` instead of `#/components/schemas/...`, though the schemas themselves were placed correctly in `components/schemas`).

