### PR TITLE
Fix the wrong code block separation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,6 @@ In your virtualenv:
 
 ```
 pip install -r requirements.txt
-```
-
-```
 pip install -r requirements-dev.txt
 make test
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ pip install https://github.com/rochacbruno/flasgger/tarball/master
 
 ## How to run tests
 
-(You may see the command in .travis.yml for "-before install" part)
+(You may see the command in [.travis.yml](./.travis.yml) for `before_install` part)
+
 In your virtualenv:
 
 ```

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ pip install -r requirements.txt
 ```
 
 ```
-pip requirements-dev.txt
+pip install -r requirements-dev.txt
 make test
 ```
 
@@ -845,7 +845,7 @@ app.json_encoder = LazyJSONEncoder
 template = dict(swaggerUiPrefix=LazyString(lambda : request.environ.get('HTTP_X_SCRIPT_NAME', '')))
 swagger = Swagger(app, template=template)
 
-``` 
+```
 
 # Customize default configurations
 
@@ -930,6 +930,6 @@ your schemas.
 
 ## Python2 Compatibility
 
-Version `0.9.5.*` will be the last verison that supports Python2. 
-Please direct discussions to [#399](https://github.com/flasgger/flasgger/issues/399). 
+Version `0.9.5.*` will be the last verison that supports Python2.
+Please direct discussions to [#399](https://github.com/flasgger/flasgger/issues/399).
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ In your virtualenv:
 
 ```
 pip install -r requirements.txt
+```
 
 ```
 pip requirements-dev.txt


### PR DESCRIPTION
Part of "Getting Started" section was misplaced in a code block