### PR TITLE
Add support for all openapi3 reusable components (#1)

### DIFF
--- a/examples/colors_openapi3_with_components.py
+++ b/examples/colors_openapi3_with_components.py
@@ -1,0 +1,81 @@
+"""
+The simple example using declared definitions with reusable components.
+"""
+
+from flask import Flask, jsonify
+
+from flasgger import Swagger, utils
+
+app = Flask(__name__)
+app.config['SWAGGER'] = {
+    'title': 'Colors API',
+    "openapi": "3.0.2",
+}
+Swagger(app)
+
+
+@app.route('/colors/<palette>/')
+def colors(palette):
+    """Example endpoint return a list of colors by palette
+    This is using docstring for specifications
+    ---
+    tags:
+      - colors
+    parameters:
+      - $ref: "#/components/parameters/PaletteParameter"
+    components:
+      schemas:
+        Palette:
+          type: object
+          properties:
+            palette_name:
+              type: array
+              items:
+                $ref: '#/components/schemas/Color'
+        Color:
+          type: string
+      parameters:
+        PaletteParameter:
+          in: path
+          type: string
+          enum: ['all', 'rgb', 'cmyk']
+          required: true
+          default: all
+          description: Which palette to filter?
+    responses:
+      200:
+        description: A list of colors (may be filtered by palette)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Palette'
+            examples:
+              rgb: ['red', 'green', 'blue']
+    """
+    all_colors = {
+        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
+        'rgb': ['red', 'green', 'blue']
+    }
+    if palette == 'all':
+        result = all_colors
+    else:
+        result = {palette: all_colors.get(palette)}
+
+    return jsonify(result)
+
+
+def test_swag(client, specs_data):
+    """
+    This test is runs automatically in Travis CI
+
+    :param client: Flask app test client
+    :param specs_data: {'url': {swag_specs}} for every spec in app
+    """
+    for url, spec in specs_data.items():
+        assert 'Palette' in spec['components']['schemas']
+        assert 'Color' in spec['components']['schemas']
+        assert 'PaletteParameter' in spec['components']['parameters']
+        assert 'colors' in spec['paths']['/colors/{palette}/']['get']['tags']
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -32,7 +32,9 @@ except ImportError:
     RequestParser = None
 import jsonschema
 from mistune import markdown
-from .constants import OPTIONAL_FIELDS, OPTIONAL_OAS3_FIELDS
+from .constants import OAS3_SUB_COMPONENTS
+from .constants import OPTIONAL_FIELDS
+from .constants import OPTIONAL_OAS3_FIELDS
 from .utils import LazyString
 from .utils import extract_definitions
 from .utils import get_schema_specs
@@ -433,20 +435,36 @@ class Swagger(object):
             openapi_version=openapi_version,
             doc_dir=self.config.get('doc_dir'))
 
+        def merge_sub_component(dest, key, source):
+            if len(source) > 0 and dest.get(key) is None:
+                dest[key] = {}
+            if len(source) > 0 and len(dest[key]) >= 0:
+                dest[key].update(source)
+
         http_methods = ['get', 'post', 'put', 'delete']
         for rule, verbs in specs:
             operations = dict()
             for verb, swag in verbs:
 
                 if is_openapi3(openapi_version):
-                    update_dict = swag.get('components', {}).get('schemas', {})
+                    source_components = swag.get('components', {})
+                    update_schemas = source_components.get('schemas', {})
+                    # clone list so we can modify
+                    active_sub_components = OAS3_SUB_COMPONENTS[:]
+                    # schemas are handled separately, so remove them here
+                    active_sub_components.remove("schemas")
+                    for subcomponent in OAS3_SUB_COMPONENTS:
+                        merge_sub_component(data['components'], subcomponent,
+                                            source_components.get(subcomponent,
+                                            {}))
                 else:  # openapi2
-                    update_dict = swag.get('definitions', {})
+                    update_schemas = swag.get('definitions', {})
 
-                if type(update_dict) == list and type(update_dict[0]) == dict:
+                if type(update_schemas) == list \
+                        and type(update_schemas[0]) == dict:
                     # pop, assert single element
-                    update_dict, = update_dict
-                definitions.update(update_dict)
+                    update_schemas, = update_schemas
+                definitions.update(update_schemas)
                 defs = []  # swag.get('definitions', [])
                 defs += extract_definitions(
                     defs, endpoint=rule.endpoint, verb=verb,

--- a/flasgger/constants.py
+++ b/flasgger/constants.py
@@ -7,6 +7,11 @@ OPTIONAL_OAS3_FIELDS = [
     'components', 'servers'
 ]
 
+OAS3_SUB_COMPONENTS = [
+    "parameters", "securitySchemes", "requestBodies", "responses",
+    "headers", "examples", "links", "callbacks", "schemas"
+]
+
 DEFAULT_FIELDS = {"tags": [], "consumes": ['application/json'],
                   "produces": ['application/json'], "schemes": [],
                   "security": [], "deprecated": False, "operationId": "",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ PyYAML>=3.0
 jsonschema>=3.0.1
 six>=1.10.0
 mistune
-werkzeug
+werkzeug==2.0.2


### PR DESCRIPTION
Add support for all openapi3 reusable components

(e.g. https://swagger.io/docs/specification/components/ , which is where I got the list of potential sections). 

I kept the testing of schemas as separate, as I wasn't sure why that was done, and wanted to leave it alone. 