### PR TITLE
Resolve #562 - Incompatibility with flask 2.3

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -17,7 +17,6 @@ except ImportError:
 from functools import wraps, partial
 from collections import defaultdict
 from flask import Blueprint
-from flask import Markup
 from flask import current_app
 from flask import jsonify, Response
 from flask import redirect
@@ -31,6 +30,7 @@ try:
 except ImportError:
     RequestParser = None
 import jsonschema
+from markupsafe import Markup
 from mistune import markdown
 from .constants import OPTIONAL_FIELDS, OPTIONAL_OAS3_FIELDS
 from .utils import LazyString

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -25,7 +25,7 @@ from flask import render_template
 from flask import request, url_for
 from flask import abort
 from flask.views import MethodView
-from flask.json import JSONEncoder
+from flask.json.provider import DefaultJSONProvider
 try:
     from flask_restful.reqparse import RequestParser
 except ImportError:
@@ -895,7 +895,7 @@ class Swagger(object):
 Flasgger = Swagger  # noqa
 
 
-class LazyJSONEncoder(JSONEncoder):
+class LazyJSONEncoder(DefaultJSONProvider):
     def default(self, obj):
         if isinstance(obj, LazyString):
             return str(obj)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -24,13 +24,19 @@ from flask import render_template
 from flask import request, url_for
 from flask import abort
 from flask.views import MethodView
-from flask.json.provider import DefaultJSONProvider
+try:
+    from flask.json.provider import DefaultJSONProvider
+except ImportError:
+    from flask.json import JSONEncoder as DefaultJSONProvider
 try:
     from flask_restful.reqparse import RequestParser
 except ImportError:
     RequestParser = None
 import jsonschema
-from markupsafe import Markup
+try:
+    from markupsafe import Markup
+except ImportError:
+    from flask import Markup
 from mistune import markdown
 from .constants import OPTIONAL_FIELDS, OPTIONAL_OAS3_FIELDS
 from .utils import LazyString


### PR DESCRIPTION
#562 

Flask 2.3 no longer uses `JSONEncoder`, instead it uses `DefaultJSONProvider`.

This PR updates to the new implementation. Also, importing `Markup` from flask is now deprecated, so this PR also updates that import to come from the flask sub-dependency of `markupsafe`.