### PR TITLE
Replace app.json_encoder with app.json and app.json_provider_class in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,8 +814,8 @@ from flasgger import, Swagger, LazyString, LazyJSONEncoder
 app = Flask(__init__)
 
 # Set the custom Encoder (Inherit it if you need to customize)
-app.json_encoder = LazyJSONEncoder
-
+app.json_provider_class = LazyJSONEncoder
+app.json = LazyJSONEncoder(app)
 
 template = dict(
     info={
@@ -844,7 +844,8 @@ from flask import Flask, request
 from flasgger import Swagger, LazyString, LazyJSONEncoder
 
 app = Flask(__name__)
-app.json_encoder = LazyJSONEncoder
+app.json_provider_class = LazyJSONEncoder
+app.json = LazyJSONEncoder(app)
 
 template = dict(swaggerUiPrefix=LazyString(lambda : request.environ.get('HTTP_X_SCRIPT_NAME', '')))
 swagger = Swagger(app, template=template)

--- a/README.zh.md
+++ b/README.zh.md
@@ -710,8 +710,8 @@ from flasgger import, Swagger, LazyString, LazyJSONEncoder
 app = Flask(__init__)
 
 # 设置自定义编码器（如果需要自定义，则继承它）
-app.json_encoder = LazyJSONEncoder
-
+app.json_provider_class = LazyJSONEncoder
+app.json = LazyJSONEncoder(app)
 
 template = dict(
     info={


### PR DESCRIPTION
`app.json_encoder` was [removed in Flask2.3](https://github.com/pallets/flask/pull/4995). Update docs to reflect that users need to set `app.json` and `app.json_provider_class` from now on.