### PR TITLE
fix two errors examples/apispec_example.py

### DIFF
--- a/examples/apispec_example.py
+++ b/examples/apispec_example.py
@@ -47,10 +47,10 @@ def random_pet():
                 $ref: '#/definitions/Pet'
     """
     pet = {'category': [{'id': 1, 'name': 'rodent'}], 'name': 'Mickey'}
-    return jsonify(PetSchema().dump(pet).data)
+    return jsonify(PetSchema().dump(pet))
 
 @app.route("/add", methods=["POST"])
-def create_pet(body: PetSchema) :
+def create_pet() :
     """Create a cute furry animal endpoint.
     ---
     post:


### PR DESCRIPTION
If you run this example, errors will occur when you enter http://127.0.0.1:5000/apidocs/ and Execute /add and /random. I have fixed them.

### /random
Starting from version 3.0, marshmallow directly returns serialized data after a dump, no longer having data.
```
Traceback (most recent call last):
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 2213, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 2193, in wsgi_app
    response = self.handle_exception(e)
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 2190, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 1486, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/Users/billvsme/temp/flasgger/examples/apispec_example.py", line 50, in random_pet
    return jsonify(PetSchema().dump(pet).data)
AttributeError: 'dict' object has no attribute 'data'
```

### /add
The error with /add is due to the fact that the POST method's body doesn't need to be specified in the view function, as its parameters are used in the URL instead. If you need to access the content of a POST's body, you can use request.data or requst.data within your view.
```
Traceback (most recent call last):
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 2213, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 2193, in wsgi_app
    response = self.handle_exception(e)
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 2190, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 1486, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/billvsme/.venv/openapi/lib/python3.9/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
TypeError: create_pet() missing 1 required positional argument: 'body'
```