### PR TITLE
Fix Schema with no required fields crashes (#598)

### DIFF
--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -144,7 +144,7 @@ def convert_schemas(d, definitions=None):
             if k == 'parameters':
                 new[k] = schema2parameters(v, location=v.swag_in)
                 new[k][0]['schema'] = ref
-                if len(definitions[v.__name__]['required']) != 0:
+                if 'required' in definitions[v.__name__] and len(definitions[v.__name__]['required']) != 0:
                     new[k][0]['required'] = True
             else:
                 new[k] = ref


### PR DESCRIPTION
### If none of the required=True schemas is set, an error message will be displayed
```python
# error
class LocationInfo(Schema):
    ip = fields.IPv4()
    location = fields.Str(metadata={'example': '4A'})

# Setting required=True will result in no error
class LocationInfo(Schema):
    ip = fields.IPv4(required=True)
    location = fields.Str(metadata={'example': '4A'})
```

>     if len(definitions[v.__name__]['required']) != 0:
>           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
> KeyError: 'required'

### So I added check if required exists before reading
