### PR TITLE
Add 'swagger_custom_css_styles' config variable to append custom CSS, combined with multiple recent fixes from pending PR's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,7 @@ target/
 *.swp
 .eggs/
 venv/
+.venv/
 .activate.sh
 .deactivate.sh
+.pypirc

--- a/HISTORY
+++ b/HISTORY
@@ -3,6 +3,13 @@ Changelog
 
 These are all the changes in Flasgger since the 0.6.0 release
 
+0.9.7b3
+- Remove dependency 'six' as Python2 support was removed
+- Fix wrong assumption that the value passed for 'uiversion' is always numeric
+- Remove unnecessary debug message
+- Add optional 'proxy_url' config variable to use when path to static are not relative
+- Add new 'swagger_custom_css_styles' optional variable to pass/append custom CSS styles in the head
+
 0.9.7b2
 -----
 - chore: noqa for APISpecsView.get bare exception with json.dumps fallback (exception logging preserved)

--- a/examples/apispec_example.py
+++ b/examples/apispec_example.py
@@ -47,10 +47,10 @@ def random_pet():
                 $ref: '#/definitions/Pet'
     """
     pet = {'category': [{'id': 1, 'name': 'rodent'}], 'name': 'Mickey'}
-    return jsonify(PetSchema().dump(pet).data)
+    return jsonify(PetSchema().dump(pet))
 
 @app.route("/add", methods=["POST"])
-def create_pet(body: PetSchema) :
+def create_pet() :
     """Create a cute furry animal endpoint.
     ---
     post:

--- a/examples/apispec_example_uiversion3.py
+++ b/examples/apispec_example_uiversion3.py
@@ -48,7 +48,7 @@ def random_pet():
                 $ref: '#/definitions/Pet'
     """
     pet = {'category': [{'id': 1, 'name': 'rodent'}], 'name': 'Mickey'}
-    return jsonify(PetSchema().dump(pet).data)
+    return jsonify(PetSchema().dump(pet))
 
 
 template = spec.to_flasgger(

--- a/flasgger/__init__.py
+++ b/flasgger/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '0.9.7.1'
+__version__ = '0.9.7b3'
 __author__ = 'Bruno Rocha, Zixuan Rao, Flasgger team'
 __email__ = 'flasgger@flasgger.org'
 

--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -144,7 +144,7 @@ def convert_schemas(d, definitions=None):
             if k == 'parameters':
                 new[k] = schema2parameters(v, location=v.swag_in)
                 new[k][0]['schema'] = ref
-                if len(definitions[v.__name__]['required']) != 0:
+                if 'required' in definitions[v.__name__] and len(definitions[v.__name__]['required']) != 0:
                     new[k][0]['required'] = True
             else:
                 new[k] = ref

--- a/flasgger/ui3/templates/flasgger/head.html
+++ b/flasgger/ui3/templates/flasgger/head.html
@@ -24,4 +24,6 @@
     margin:0;
     background: #fafafa;
     }
+
+    {{ swagger_custom_css_styles | safe }}
 </style>

--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -9,7 +9,6 @@ import re
 import sys
 import jsonschema
 import yaml
-from six import string_types, text_type
 from copy import deepcopy
 from functools import wraps
 from importlib import import_module
@@ -269,7 +268,7 @@ def swag_from(
     def is_path(specs):
         """ Returns True if specs is a string or pathlib.Path
         """
-        is_str_path = isinstance(specs, string_types)
+        is_str_path = isinstance(specs, str)
         try:
             from pathlib import Path
             is_py3_path = isinstance(specs, Path)
@@ -879,56 +878,56 @@ class StringLike(object):
         Forwards any non-magic methods to the resulting string's class. This
         allows support for string methods like `upper()`, `lower()`, etc.
         """
-        string = self.text_type(self)
+        string = str(self)
         if hasattr(string, attr):
             return getattr(string, attr)
         raise AttributeError(attr)
 
     def __len__(self):
-        return len(self.text_type(self))
+        return len(str(self))
 
     def __getitem__(self, key):
-        return self.text_type(self)[key]
+        return str(self)[key]
 
     def __iter__(self):
-        return iter(self.text_type(self))
+        return iter(str(self))
 
     def __contains__(self, item):
-        return item in self.text_type(self)
+        return item in str(self)
 
     def __add__(self, other):
-        return self.text_type(self) + other
+        return str(self) + other
 
     def __radd__(self, other):
-        return other + self.text_type(self)
+        return other + str(self)
 
     def __mul__(self, other):
-        return self.text_type(self) * other
+        return str(self) * other
 
     def __rmul__(self, other):
-        return other * self.text_type(self)
+        return other * str(self)
 
     def __lt__(self, other):
-        return self.text_type(self) < other
+        return str(self) < other
 
     def __le__(self, other):
-        return self.text_type(self) <= other
+        return str(self) <= other
 
     def __eq__(self, other):
-        return self.text_type(self) == other
+        return str(self) == other
 
     def __ne__(self, other):
-        return self.text_type(self) != other
+        return str(self) != other
 
     def __gt__(self, other):
-        return self.text_type(self) > other
+        return str(self) > other
 
     def __ge__(self, other):
-        return self.text_type(self) >= other
+        return str(self) >= other
 
     @property
     def text_type(self):
-        return text_type
+        return str
 
 
 class LazyString(StringLike):
@@ -948,7 +947,7 @@ class LazyString(StringLike):
         """
         Returns the actual string.
         """
-        return self.text_type(self._func())
+        return str(self._func())
 
 
 class CachedLazyString(LazyString):
@@ -968,7 +967,7 @@ class CachedLazyString(LazyString):
         Returns the actual string and caches the result.
         """
         if not self._cache:
-            self._cache = self.text_type(self._func())
+            self._cache = str(self._func())
         return self._cache
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 Flask>=0.10
 PyYAML>=3.0
 jsonschema>=3.0.1
-six>=1.10.0
 mistune
 werkzeug
 packaging

--- a/setup.py
+++ b/setup.py
@@ -54,13 +54,15 @@ setup(
         'PyYAML>=3.0',
         'jsonschema>=3.0.1',
         'mistune',
-        'six>=1.10.0',
         'packaging',
     ],
     classifiers=[
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
     ],
     entry_points={
         'flask.commands': [


### PR DESCRIPTION


Combining solutions revised and tested from other recent pending PRs along with the implementation of the 'swagger_custom_css_styles' optional config variable to append additional custom styles in the html head without the need of alter the default linked css file.

Version updated to 0.9.7b3
