### PR TITLE
Remove use of six

### DIFF
--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -9,7 +9,6 @@ import re
 import sys
 import jsonschema
 import yaml
-from six import string_types, text_type
 from copy import deepcopy
 from functools import wraps
 from importlib import import_module
@@ -269,7 +268,7 @@ def swag_from(
     def is_path(specs):
         """ Returns True if specs is a string or pathlib.Path
         """
-        is_str_path = isinstance(specs, string_types)
+        is_str_path = isinstance(specs, str)
         try:
             from pathlib import Path
             is_py3_path = isinstance(specs, Path)
@@ -928,7 +927,7 @@ class StringLike(object):
 
     @property
     def text_type(self):
-        return text_type
+        return str
 
 
 class LazyString(StringLike):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 Flask>=0.10
 PyYAML>=3.0
 jsonschema>=3.0.1
-six>=1.10.0
 mistune
 werkzeug
 packaging

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'PyYAML>=3.0',
         'jsonschema>=3.0.1',
         'mistune',
-        'six>=1.10.0',
         'packaging',
     ],
     classifiers=[


### PR DESCRIPTION
Now that Python 2 support has been removed, we can stop using the crutch of six to support both versions. StringLike could probably be refactored now to be a subclass of str, but I have left that alone to make this diff small.